### PR TITLE
Add Spring 3.5.0 project template

### DIFF
--- a/spring-3.5.0-template/README.md
+++ b/spring-3.5.0-template/README.md
@@ -1,0 +1,15 @@
+# Spring 3.5.0 Template
+
+This directory contains a minimal Spring Boot project configured for version `3.5.0`.
+
+## Quick start
+
+```bash
+# build the project
+mvn clean package
+
+# run the application
+mvn spring-boot:run
+```
+
+Running `mvn test` will execute a simple context load test.

--- a/spring-3.5.0-template/pom.xml
+++ b/spring-3.5.0-template/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>demo</name>
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.5.0</spring.boot.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-3.5.0-template/src/main/java/com/example/demo/DemoApplication.java
+++ b/spring-3.5.0-template/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,11 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/spring-3.5.0-template/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/spring-3.5.0-template/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple Spring Boot 3.5.0 template using Maven
- include an application class and a basic test
- provide usage instructions in a README

## Testing
- `mvn test` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430c59a03c8323b21473ee40172bb0