### PR TITLE
Add Hello World REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 
 ## Usage
 
+Run the Spring Boot application and access `http://localhost:8080/hello` to get the
+response `Hello World`.
+
 ## Installation
 
 ## References

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,8 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter")
+        implementation("org.springframework.boot:spring-boot-starter")
+        implementation("org.springframework.boot:spring-boot-starter-web")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,14 @@
 		<java.version>24</java.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/microsoft/com/shinyay/HelloController.java
+++ b/src/main/java/com/microsoft/com/shinyay/HelloController.java
@@ -1,0 +1,13 @@
+package com.microsoft.com.shinyay;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello World";
+    }
+}

--- a/src/test/java/com/microsoft/com/shinyay/DemoApplicationTests.java
+++ b/src/test/java/com/microsoft/com/shinyay/DemoApplicationTests.java
@@ -1,13 +1,26 @@
 package com.microsoft.com.shinyay;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class DemoApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void helloEndpointReturnsHelloWorld() throws Exception {
+                mockMvc.perform(get("/hello"))
+                                .andExpect(status().isOk())
+                                .andExpect(content().string("Hello World"));
+        }
 
 }


### PR DESCRIPTION
## Summary
- add Spring Web as dependency
- implement `HelloController`
- test `/hello` endpoint returns `Hello World`
- document usage of the endpoint

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./mvnw -q test` *(fails: Failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6843193deab083239f51cf0ca0acf3a4